### PR TITLE
Install local babel cli so compile doesn't depend on global version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "bugs": "http://github.com/jessebeach/quail-cli/issues",
   "dependencies": {
+    "babel-cli": "^6.6.5",
     "babel-plugin-transform-object-rest-spread": "^6.3.13",
     "babel-polyfill": "^6.2.0",
     "babel-preset-es2015": "^6.3.13",


### PR DESCRIPTION
I ran into trouble building the quail-cli project because I didn't have babel installed globally. Adding it to the project and running it locally seems preferable to assuming a global install.

I expected to have to modify the 'compile' npm script to look in node_modules/.bin for babel, but it worked fine after installing babel-cli in the project.
